### PR TITLE
🐛 fix risk steward import issue

### DIFF
--- a/generator/templates/proposal.template.ts
+++ b/generator/templates/proposal.template.ts
@@ -11,9 +11,6 @@ export const proposalTemplate = (
   const {title, author, discussion} = options;
   const chain = getPoolChain(pool);
 
-  // Edge case: use BaseChain instead of Base for RiskStewards network
-  const riskStewardChain = chain === 'Base' ? 'BaseChain' : chain;
-
   const folderName = generateFolderName(options);
   const contractName = generateContractName(options, pool);
 
@@ -31,7 +28,7 @@ export const proposalTemplate = (
     chain
   )} broadcast=false generate_diff=true
   */
- contract ${contractName} is ${`RiskStewards${riskStewardChain}`} {
+ contract ${contractName} is ${`RiskStewards${chain === 'Base' ? 'BaseChain' : chain}`} {
   function name() public pure override returns (string memory) {
     return '${contractName}';
   }

--- a/generator/templates/proposal.template.ts
+++ b/generator/templates/proposal.template.ts
@@ -6,10 +6,14 @@ import {prefixWithPragma} from '../utils/constants';
 export const proposalTemplate = (
   options: Options,
   poolConfig: PoolConfig,
-  pool: PoolIdentifier,
+  pool: PoolIdentifier
 ) => {
   const {title, author, discussion} = options;
   const chain = getPoolChain(pool);
+
+  // Edge case: use BaseChain instead of Base for RiskStewards network
+  const riskStewardChain = chain === 'Base' ? 'BaseChain' : chain;
+
   const folderName = generateFolderName(options);
   const contractName = generateContractName(options, pool);
 
@@ -23,10 +27,11 @@ export const proposalTemplate = (
   * @title ${title || 'TODO'}
   * @author ${author || 'TODO'}
   * - discussion: ${discussion || 'TODO'}
-  * - deploy-command: make run-script contract=src/contracts/updates/${folderName}/${contractName}.sol:${contractName} network=${getChainAlias(chain)} broadcast=false generate_diff=true
+  * - deploy-command: make run-script contract=src/contracts/updates/${folderName}/${contractName}.sol:${contractName} network=${getChainAlias(
+    chain
+  )} broadcast=false generate_diff=true
   */
- contract ${contractName} is ${`RiskStewards${chain}`
- } {
+ contract ${contractName} is ${`RiskStewards${riskStewardChain}`} {
   function name() public pure override returns (string memory) {
     return '${contractName}';
   }


### PR DESCRIPTION
For the Base chain contract generation, the generator use the contract `RiskStewardsBase` (which is the contract on which all networks inherit from) instead of `RiskStewardsBaseChain` (which is the base network contract).
To avoid this edge case, I set a condition to rename correctly the RiskSteward contract on Base network.