### PR TITLE
✨ Caps update timelock error skip flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ git-diff :
 deploy-ledger :; FOUNDRY_PROFILE=${chain} forge script $(if $(filter zksync,${chain}),--zksync) ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv, --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify -vvvv --slow --broadcast)
 deploy-pk :; FOUNDRY_PROFILE=${chain} forge script $(if $(filter zksync,${chain}),--zksync) ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv, --private-key ${PRIVATE_KEY} --verify -vvvv --slow --broadcast)
 
-run-script:; FOUNDRY_PROFILE=${network} forge script ${contract} --rpc-url ${network} --sig "run(bool, bool)" ${broadcast} ${generate_diff} -vv
+run-script:; FOUNDRY_PROFILE=${network} forge script ${contract} --rpc-url ${network} --sig "run(bool, bool, bool)" ${broadcast} ${generate_diff} ${skip_timelock} -vv

--- a/README.md
+++ b/README.md
@@ -171,7 +171,13 @@ $ tsx generator/cli
 
 The generator generates the scripts for doing the updates in `src/contracts/updates` directory.
 
-The script can be executed by running: `make run-script network=mainnet contract_path=src/contracts/examples/EthereumExample.sol:EthereumExample broadcast=false generate_diff=true` where the bool inside the `broadcast=` determines if the calldata should be sent to safe and `generate_diff=` determines if diff report should be generated. The script also emits the calldata for doing the update in the console which can be used on the safe manually as well.
+The script can be executed by running: `make run-script network=mainnet contract_path=src/contracts/examples/EthereumExample.sol:EthereumExample broadcast=false generate_diff=true skip_timelock=false` where:
+
+- `broadcast=` determines if the calldata should be sent to safe
+- `generate_diff=` determines if diff report should be generated
+- `skip_timelock=` determines if caps update timelock errors should revert the script
+
+The script also emits the calldata for doing the update in the console which can be used on the safe manually as well.
 
 ### Before I will submit anything to sign, how do I test out the update, or get visibility from what will happen?
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The script can be executed by running: `make run-script network=mainnet contrac
 
 - `broadcast=` determines if the calldata should be sent to safe
 - `generate_diff=` determines if diff report should be generated
-- `skip_timelock=` determines if caps update timelock errors should revert the script
+- `skip_timelock=` determines if timelock errors should revert the script, helpful in generating diff report / calldata when the current timelock has not ended.
 
 The script also emits the calldata for doing the update in the console which can be used on the safe manually as well.
 

--- a/generator/templates/proposal.template.ts
+++ b/generator/templates/proposal.template.ts
@@ -6,7 +6,7 @@ import {prefixWithPragma} from '../utils/constants';
 export const proposalTemplate = (
   options: Options,
   poolConfig: PoolConfig,
-  pool: PoolIdentifier,
+  pool: PoolIdentifier
 ) => {
   const {title, author, discussion} = options;
   const chain = getPoolChain(pool);
@@ -23,10 +23,11 @@ export const proposalTemplate = (
   * @title ${title || 'TODO'}
   * @author ${author || 'TODO'}
   * - discussion: ${discussion || 'TODO'}
-  * - deploy-command: make run-script contract=src/contracts/updates/${folderName}/${contractName}.sol:${contractName} network=${getChainAlias(chain)} broadcast=false generate_diff=true
+  * - deploy-command: make run-script contract=src/contracts/updates/${folderName}/${contractName}.sol:${contractName} network=${getChainAlias(
+    chain
+  )} broadcast=false generate_diff=true skip_timelock=false
   */
- contract ${contractName} is ${`RiskStewards${chain}`
- } {
+ contract ${contractName} is ${`RiskStewards${chain}`} {
   function name() public pure override returns (string memory) {
     return '${contractName}';
   }

--- a/scripts/RiskStewardsBase.s.sol
+++ b/scripts/RiskStewardsBase.s.sol
@@ -6,7 +6,6 @@ import {IRiskSteward} from '../src/interfaces/IRiskSteward.sol';
 import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
 import {IOwnable} from 'aave-address-book/common/IOwnable.sol';
 import {IACLManager} from 'aave-address-book/AaveV3.sol';
-import {IRiskSteward} from '../src/interfaces/IRiskSteward.sol';
 
 abstract contract RiskStewardsBase is ProtocolV3TestBase {
   error FailedUpdate();

--- a/src/contracts/examples/ArbitrumExample.sol
+++ b/src/contracts/examples/ArbitrumExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsArbitrum} from '../../../scripts/networks/RiskStewardsArbitrum.s.sol';
 
-// make run-script network=arbitrum contract=src/contracts/examples/ArbitrumExample.sol:ArbitrumExample broadcast=false generate_diff=true
+// make run-script network=arbitrum contract=src/contracts/examples/ArbitrumExample.sol:ArbitrumExample broadcast=false generate_diff=true skip_timelock=false
 contract ArbitrumExample is RiskStewardsArbitrum {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/AvalancheExample.sol
+++ b/src/contracts/examples/AvalancheExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsAvalanche} from '../../../scripts/networks/RiskStewardsAvalanche.s.sol';
 
-// make run-script network=avalanche contract=src/contracts/examples/AvalancheExample.sol:AvalancheExample broadcast=false generate_diff=true
+// make run-script network=avalanche contract=src/contracts/examples/AvalancheExample.sol:AvalancheExample broadcast=false generate_diff=true skip_timelock=false
 contract AvalancheExample is RiskStewardsAvalanche {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/BNBExample.sol
+++ b/src/contracts/examples/BNBExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsBNB} from '../../../scripts/networks/RiskStewardsBNB.s.sol';
 
-// make run-script network=bnb contract=src/contracts/examples/BNBExample.sol:BNBExample broadcast=false generate_diff=true
+// make run-script network=bnb contract=src/contracts/examples/BNBExample.sol:BNBExample broadcast=false generate_diff=true skip_timelock=false
 contract BNBExample is RiskStewardsBNB {
   /**
    * @return string name identifier used for the diff
@@ -15,7 +15,12 @@ contract BNBExample is RiskStewardsBNB {
     return 'bnb_example';
   }
 
-  function rateStrategiesUpdates() public pure override returns (IEngine.RateStrategyUpdate[] memory) {
+  function rateStrategiesUpdates()
+    public
+    pure
+    override
+    returns (IEngine.RateStrategyUpdate[] memory)
+  {
     IEngine.RateStrategyUpdate[] memory rateUpdates = new IEngine.RateStrategyUpdate[](1);
     rateUpdates[0] = IEngine.RateStrategyUpdate({
       asset: AaveV3BNBAssets.ETH_UNDERLYING,

--- a/src/contracts/examples/BaseExample.sol
+++ b/src/contracts/examples/BaseExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsBaseChain} from '../../../scripts/networks/RiskStewardsBaseChain.s.sol';
 
-// make run-script network=base contract=src/contracts/examples/BaseExample.sol:BaseExample broadcast=false generate_diff=true
+// make run-script network=base contract=src/contracts/examples/BaseExample.sol:BaseExample broadcast=false generate_diff=true skip_timelock=false
 contract BaseExample is RiskStewardsBaseChain {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/EthereumExample.sol
+++ b/src/contracts/examples/EthereumExample.sol
@@ -7,7 +7,7 @@ import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-eng
 import {RiskStewardsEthereum} from '../../../scripts/networks/RiskStewardsEthereum.s.sol';
 import {IRiskSteward, IPriceCapAdapter} from '../../interfaces/IRiskSteward.sol';
 
-// make run-script network=mainnet contract=src/contracts/examples/EthereumExample.sol:EthereumExample broadcast=false generate_diff=true
+// make run-script network=mainnet contract=src/contracts/examples/EthereumExample.sol:EthereumExample broadcast=false generate_diff=true skip_timelock=false
 contract EthereumExample is RiskStewardsEthereum {
   /**
    * @return string name identifier used for the diff
@@ -16,8 +16,15 @@ contract EthereumExample is RiskStewardsEthereum {
     return 'ethereum_example';
   }
 
-  function lstPriceCapsUpdates() public pure override returns (IRiskSteward.PriceCapLstUpdate[] memory) {
-    IRiskSteward.PriceCapLstUpdate[] memory priceCapUpdates = new IRiskSteward.PriceCapLstUpdate[](1);
+  function lstPriceCapsUpdates()
+    public
+    pure
+    override
+    returns (IRiskSteward.PriceCapLstUpdate[] memory)
+  {
+    IRiskSteward.PriceCapLstUpdate[] memory priceCapUpdates = new IRiskSteward.PriceCapLstUpdate[](
+      1
+    );
 
     priceCapUpdates[0] = IRiskSteward.PriceCapLstUpdate({
       oracle: AaveV3EthereumAssets.wstETH_ORACLE,

--- a/src/contracts/examples/EthereumLidoExample.sol
+++ b/src/contracts/examples/EthereumLidoExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsEthereumLido} from '../../../scripts/networks/RiskStewardsEthereumLido.s.sol';
 
-// make run-script network=mainnet contract=src/contracts/examples/EthereumLidoExample.sol:EthereumLidoExample broadcast=false generate_diff=true
+// make run-script network=mainnet contract=src/contracts/examples/EthereumLidoExample.sol:EthereumLidoExample broadcast=false generate_diff=true skip_timelock=false
 contract EthereumLidoExample is RiskStewardsEthereumLido {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/GnosisExample.sol
+++ b/src/contracts/examples/GnosisExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsGnosis} from '../../../scripts/networks/RiskStewardsGnosis.s.sol';
 
-// make run-script network=gnosis contract=src/contracts/examples/GnosisExample.sol:GnosisExample broadcast=false generate_diff=true
+// make run-script network=gnosis contract=src/contracts/examples/GnosisExample.sol:GnosisExample broadcast=false generate_diff=true skip_timelock=false
 contract GnosisExample is RiskStewardsGnosis {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/MetisExample.sol
+++ b/src/contracts/examples/MetisExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsMetis} from '../../../scripts/networks/RiskStewardsMetis.s.sol';
 
-// make run-script network=metis contract=src/contracts/examples/MetisExample.sol:MetisExample broadcast=false generate_diff=true
+// make run-script network=metis contract=src/contracts/examples/MetisExample.sol:MetisExample broadcast=false generate_diff=true skip_timelock=false
 contract MetisExample is RiskStewardsMetis {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/OptimismExample.sol
+++ b/src/contracts/examples/OptimismExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsOptimism} from '../../../scripts/networks/RiskStewardsOptimism.s.sol';
 
-// make run-script network=optimism contract=src/contracts/examples/OptimismExample.sol:OptimismExample broadcast=false generate_diff=true
+// make run-script network=optimism contract=src/contracts/examples/OptimismExample.sol:OptimismExample broadcast=false generate_diff=true skip_timelock=false
 contract OptimismExample is RiskStewardsOptimism {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/PolygonExample.sol
+++ b/src/contracts/examples/PolygonExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsPolygon} from '../../../scripts/networks/RiskStewardsPolygon.s.sol';
 
-// make run-script network=polygon contract=src/contracts/examples/PolygonExample.sol:PolygonExample broadcast=false generate_diff=true
+// make run-script network=polygon contract=src/contracts/examples/PolygonExample.sol:PolygonExample broadcast=false generate_diff=true skip_timelock=false
 contract PolygonExample is RiskStewardsPolygon {
   /**
    * @return string name identifier used for the diff

--- a/src/contracts/examples/ScrollExample.sol
+++ b/src/contracts/examples/ScrollExample.sol
@@ -6,7 +6,7 @@ import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/exten
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {RiskStewardsScroll} from '../../../scripts/networks/RiskStewardsScroll.s.sol';
 
-// make run-script network=scroll contract=src/contracts/examples/ScrollExample.sol:ScrollExample broadcast=false generate_diff=true
+// make run-script network=scroll contract=src/contracts/examples/ScrollExample.sol:ScrollExample broadcast=false generate_diff=true skip_timelock=false
 contract ScrollExample is RiskStewardsScroll {
   /**
    * @return string name identifier used for the diff


### PR DESCRIPTION
This PR add a `skip_timelock` flag that allow to skip issue related to timelock on caps update.
It allows to do all the other checks and still see the calldata.