### PR TITLE
🐛 fix issue on RiskStewards contract name for same chain pools

### DIFF
--- a/generator/common.ts
+++ b/generator/common.ts
@@ -50,6 +50,10 @@ export function getPoolChain(pool: PoolIdentifier) {
   return chain;
 }
 
+export function getPoolSuffix(pool: PoolIdentifier) {
+  return pool.replace('AaveV3', '');
+}
+
 export function getDate() {
   const date = new Date();
   const years = date.getFullYear();

--- a/generator/templates/proposal.template.ts
+++ b/generator/templates/proposal.template.ts
@@ -1,4 +1,10 @@
-import {generateContractName, getPoolChain, generateFolderName, getChainAlias} from '../common';
+import {
+  generateContractName,
+  getPoolChain,
+  generateFolderName,
+  getChainAlias,
+  getPoolSuffix,
+} from '../common';
 import {Options, PoolConfig, PoolIdentifier} from '../types';
 import {prefixWithImports} from '../utils/importsResolver';
 import {prefixWithPragma} from '../utils/constants';
@@ -10,6 +16,7 @@ export const proposalTemplate = (
 ) => {
   const {title, author, discussion} = options;
   const chain = getPoolChain(pool);
+  const poolSuffix = getPoolSuffix(pool);
 
   const folderName = generateFolderName(options);
   const contractName = generateContractName(options, pool);
@@ -24,11 +31,13 @@ export const proposalTemplate = (
   * @title ${title || 'TODO'}
   * @author ${author || 'TODO'}
   * - discussion: ${discussion || 'TODO'}
-  * - deploy-command: make run-script contract=${chain == 'ZkSync' ? 'zksync/' : ''}src/contracts/updates/${folderName}/${contractName}.sol:${contractName} network=${getChainAlias(
+  * - deploy-command: make run-script contract=${
+    chain == 'ZkSync' ? 'zksync/' : ''
+  }src/contracts/updates/${folderName}/${contractName}.sol:${contractName} network=${getChainAlias(
     chain
   )} broadcast=false generate_diff=true skip_timelock=false
   */
- contract ${contractName} is ${`RiskStewards${chain === 'Base' ? 'BaseChain' : chain}`} {
+ contract ${contractName} is ${`RiskStewards${poolSuffix === 'Base' ? 'BaseChain' : poolSuffix}`} {
   function name() public pure override returns (string memory) {
     return '${contractName}';
   }


### PR DESCRIPTION
Issue: the generator doesn't use the right `RiskStewards` contract name on the file it generates. It uses the chain name instead of the pool name. So pools like Lido or Etherfi use the same `RiskStewardsEthereum` instead of their own. 
This leads to the execution of calldatas that return errors because they are simulated on the wrong RiskStewards address.

Instead of getting the chain name to compute the `RiskStewards` contract name, we now use the suffix of Pool names.
So: `AaveV3EthereumLido` => `EthereumLido`

Tested locally contract on Core and Prime pool: ✅