### PR TITLE
⬆️ Update aave-helpers lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "lib/aave-helpers"]
 	path = lib/aave-helpers
 	url = https://github.com/bgd-labs/aave-helpers
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/aave-helpers"]
 	path = lib/aave-helpers
 	url = https://github.com/bgd-labs/aave-helpers
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = 'src'
 test = 'tests'
 script = 'scripts'
 out = 'out'
-solc = '0.8.20'
+solc = '0.8.22'
 optimizer = true
 optimizer_runs = 200
 libs = ['lib']
@@ -18,7 +18,7 @@ src = 'zksync'
 test = 'zksync'
 script = 'scripts'
 libs = ['lib']
-solc = '0.8.20'
+solc = '0.8.22'
 fs_permissions = [{ access = "write", path = "./reports" }]
 ffi = true
 evm_version = 'shanghai'

--- a/generator/utils/importsResolver.ts
+++ b/generator/utils/importsResolver.ts
@@ -41,9 +41,13 @@ function generateRiskStewardImport(code: string) {
   const match = code.match(/RiskStewards(\w+)/);
 
   if (match) {
-    imports = `import {RiskStewards${match[1]}} from '${match[1] == 'ZkSync' ? '../' : ''}../../../../scripts/networks/RiskStewards${match[1]}.s.sol';\n`;
+    imports = `import {RiskStewards${match[1]}} from '${
+      match[1] == 'ZkSync' ? '../' : ''
+    }../../../../scripts/networks/RiskStewards${match[1]}.s.sol';\n`;
     if (findMatch(code, 'IRiskSteward')) {
-      imports += `import {IRiskSteward${findMatch(code, 'IPriceCapAdapter') ? ', IPriceCapAdapter': ''}} from '../../../interfaces/IRiskSteward.sol';\n`;
+      imports += `import {IRiskSteward${
+        findMatch(code, 'IPriceCapAdapter') ? ', IPriceCapAdapter' : ''
+      }} from '../../../interfaces/IRiskSteward.sol';\n`;
     }
   }
   return imports;
@@ -52,9 +56,9 @@ function generateRiskStewardImport(code: string) {
 function generateEngineImport(code: string) {
   const matches = [...code.matchAll(/Aave(V[2..3])Payload([A-Za-z]+)/g)].flat();
   if (matches.length > 0)
-    return `import {${matches[0]}} from 'aave-helpers/src/${matches[1].toLowerCase()}-config-engine/${
+    return `import {${
       matches[0]
-    }.sol';\n`;
+    }} from 'aave-helpers/src/${matches[1].toLowerCase()}-config-engine/${matches[0]}.sol';\n`;
 }
 
 function findMatches(code: string, needles: string[] | readonly string[]) {
@@ -110,10 +114,10 @@ export function prefixWithImports(code: string) {
   }
   // common imports
   if (findMatch(code, 'IERC20')) {
-    imports += `import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';\n`;
+    imports += `import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';\n`;
   }
   if (findMatch(code, 'forceApprove')) {
-    imports += `import {SafeERC20} from 'solidity-utils/contracts/oz-common/SafeERC20.sol';\n`;
+    imports += `import {SafeERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';\n`;
   }
   if (findMatch(code, 'GovernanceV3Ethereum')) {
     imports += `import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';\n`;

--- a/remappings.txt
+++ b/remappings.txt
@@ -6,4 +6,3 @@ lib/aave-helpers:aave-v3-origin/=lib/aave-helpers/lib/aave-address-book/lib/aave
 aave-v3-origin/=lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/
 aave-capo/=lib/aave-capo/src
 lib/aave-capo:cl-synchronicity-price-adapter/=lib/aave-capo/lib/cl-synchronicity-price-adapter/src/
-openzeppelin-contracts/=lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/

--- a/remappings.txt
+++ b/remappings.txt
@@ -6,4 +6,4 @@ lib/aave-helpers:aave-v3-origin/=lib/aave-helpers/lib/aave-address-book/lib/aave
 aave-v3-origin/=lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/
 aave-capo/=lib/aave-capo/src
 lib/aave-capo:cl-synchronicity-price-adapter/=lib/aave-capo/lib/cl-synchronicity-price-adapter/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/
+openzeppelin-contracts/=lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/

--- a/remappings.txt
+++ b/remappings.txt
@@ -6,3 +6,4 @@ lib/aave-helpers:aave-v3-origin/=lib/aave-helpers/lib/aave-address-book/lib/aave
 aave-v3-origin/=lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/
 aave-capo/=lib/aave-capo/src
 lib/aave-capo:cl-synchronicity-price-adapter/=lib/aave-capo/lib/cl-synchronicity-price-adapter/src/
+openzeppelin-contracts/=lib/openzeppelin-contracts/

--- a/report/contracts/src/contracts/RiskSteward.sol.gcov.html
+++ b/report/contracts/src/contracts/RiskSteward.sol.gcov.html
@@ -10,16 +10,22 @@
 
 <body>
 
-          <table width="100%" border=0 cellspacing=0 cellpadding=0>
-            <tr><td class="title">LCOV - code coverage report</td></tr>
-            <tr><td class="ruler"><img src="../../../glass.png" width=3 height=3 alt=""></td></tr>
+  <table width="100%" border=0 cellspacing=0 cellpadding=0>
+    <tr>
+      <td class="title">LCOV - code coverage report</td>
+    </tr>
+    <tr>
+      <td class="ruler"><img src="../../../glass.png" width=3 height=3 alt=""></td>
+    </tr>
 
-            <tr>
-              <td width="100%">
-                <table cellpadding=1 border=0 width="100%">
+    <tr>
+      <td width="100%">
+        <table cellpadding=1 border=0 width="100%">
           <tr>
             <td width="10%" class="headerItem">Current view:</td>
-            <td width="10%" class="headerValue"><a href="../../../index.html">top level</a> - <a href="index.html">contracts/src/contracts</a> - RiskSteward.sol<span style="font-size: 80%;"> (source / <a href="RiskSteward.sol.func-c.html">functions</a>)</span></td>
+            <td width="10%" class="headerValue"><a href="../../../index.html">top level</a> - <a
+                href="index.html">contracts/src/contracts</a> - RiskSteward.sol<span style="font-size: 80%;"> (source /
+                <a href="RiskSteward.sol.func-c.html">functions</a>)</span></td>
             <td width="5%"></td>
             <td width="5%"></td>
             <td width="5%" class="headerCovTableHead">Coverage</td>
@@ -53,29 +59,33 @@
             <td class="headerCovTableEntry">0</td>
             <td class="headerCovTableEntry">0</td>
           </tr>
-                  <tr><td><img src="../../../glass.png" width=3 height=3 alt=""></td></tr>
-                </table>
-              </td>
-            </tr>
+          <tr>
+            <td><img src="../../../glass.png" width=3 height=3 alt=""></td>
+          </tr>
+        </table>
+      </td>
+    </tr>
 
-            <tr><td class="ruler"><img src="../../../glass.png" width=3 height=3 alt=""></td></tr>
-          </table>
+    <tr>
+      <td class="ruler"><img src="../../../glass.png" width=3 height=3 alt=""></td>
+    </tr>
+  </table>
 
-          <table cellpadding=0 cellspacing=0 border=0>
-            <tr>
-              <td><br></td>
-            </tr>
-            <tr>
-              <td>
-<pre class="sourceHeading">             Branch data     Line data    Source code</pre>
-<pre class="source">
+  <table cellpadding=0 cellspacing=0 border=0>
+    <tr>
+      <td><br></td>
+    </tr>
+    <tr>
+      <td>
+        <pre class="sourceHeading">             Branch data     Line data    Source code</pre>
+        <pre class="source">
 <span id="L1"><span class="lineNum">       1</span>                 :             : // SPDX-License-Identifier: BUSL-1.1</span>
 <span id="L2"><span class="lineNum">       2</span>                 :             : pragma solidity ^0.8.0;</span>
 <span id="L3"><span class="lineNum">       3</span>                 :             : </span>
 <span id="L4"><span class="lineNum">       4</span>                 :             : import {IPoolDataProvider} from 'aave-address-book/AaveV3.sol';</span>
-<span id="L5"><span class="lineNum">       5</span>                 :             : import {Address} from 'solidity-utils/contracts/oz-common/Address.sol';</span>
+<span id="L5"><span class="lineNum">       5</span>                 :             : import {Address} from 'openzeppelin-contracts/contracts/utils/Address.sol';</span>
 <span id="L6"><span class="lineNum">       6</span>                 :             : import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';</span>
-<span id="L7"><span class="lineNum">       7</span>                 :             : import {Ownable} from 'solidity-utils/contracts/oz-common/Ownable.sol';</span>
+<span id="L7"><span class="lineNum">       7</span>                 :             : import {Ownable} from 'openzeppelin-contracts/contracts/access/Ownable.sol';</span>
 <span id="L8"><span class="lineNum">       8</span>                 :             : import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/periphery/contracts/v3-config-engine/AaveV3ConfigEngine.sol';</span>
 <span id="L9"><span class="lineNum">       9</span>                 :             : import {IRiskSteward} from '../interfaces/IRiskSteward.sol';</span>
 <span id="L10"><span class="lineNum">      10</span>                 :             : import {IDefaultInterestRateStrategyV2} from 'aave-v3-origin/core/contracts/interfaces/IDefaultInterestRateStrategyV2.sol';</span>
@@ -509,16 +519,22 @@
 <span id="L438"><span class="lineNum">     438</span>                 :             :   }</span>
 <span id="L439"><span class="lineNum">     439</span>                 :             : }</span>
         </pre>
-              </td>
-            </tr>
-          </table>
-          <br>
+      </td>
+    </tr>
+  </table>
+  <br>
 
-          <table width="100%" border=0 cellspacing=0 cellpadding=0>
-            <tr><td class="ruler"><img src="../../../glass.png" width=3 height=3 alt=""></td></tr>
-            <tr><td class="versionInfo">Generated by: <a href="https://github.com//linux-test-project/lcov" target="_parent">LCOV version 2.0-1</a></td></tr>
-          </table>
-          <br>
+  <table width="100%" border=0 cellspacing=0 cellpadding=0>
+    <tr>
+      <td class="ruler"><img src="../../../glass.png" width=3 height=3 alt=""></td>
+    </tr>
+    <tr>
+      <td class="versionInfo">Generated by: <a href="https://github.com//linux-test-project/lcov" target="_parent">LCOV
+          version 2.0-1</a></td>
+    </tr>
+  </table>
+  <br>
 
 </body>
+
 </html>

--- a/src/contracts/AaveStewardInjector.sol
+++ b/src/contracts/AaveStewardInjector.sol
@@ -5,7 +5,7 @@ import {IRiskOracle} from './dependencies/IRiskOracle.sol';
 import {IRiskSteward} from '../interfaces/IRiskSteward.sol';
 import {IAaveStewardInjector, AutomationCompatibleInterface} from '../interfaces/IAaveStewardInjector.sol';
 import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
-import {Ownable} from 'solidity-utils/contracts/oz-common/Ownable.sol';
+import {Ownable} from 'openzeppelin-contracts/contracts/access/Ownable.sol';
 
 /**
  * @title AaveStewardInjector
@@ -45,7 +45,12 @@ contract AaveStewardInjector is Ownable, IAaveStewardInjector {
    * @param guardian address of the guardian / owner of the stewards injector.
    * @param whitelistedAsset address of the whitelisted asset for which update can be injected.
    */
-  constructor(address riskOracle, address riskSteward, address guardian, address whitelistedAsset) {
+  constructor(
+    address riskOracle,
+    address riskSteward,
+    address guardian,
+    address whitelistedAsset
+  ) Ownable(riskSteward) {
     RISK_ORACLE = riskOracle;
     RISK_STEWARD = riskSteward;
     WHITELISTED_ASSET = whitelistedAsset;
@@ -108,13 +113,11 @@ contract AaveStewardInjector is Ownable, IAaveStewardInjector {
   function _canUpdateBeInjected(
     IRiskOracle.RiskParameterUpdate memory updateRiskParams
   ) internal view returns (bool) {
-    return (
-      !isUpdateIdExecuted(updateRiskParams.updateId) &&
+    return (!isUpdateIdExecuted(updateRiskParams.updateId) &&
       (updateRiskParams.timestamp + EXPIRATION_PERIOD > block.timestamp) &&
       updateRiskParams.market == WHITELISTED_ASSET &&
       keccak256(bytes(updateRiskParams.updateType)) == keccak256(bytes(WHITELISTED_UPDATE_TYPE)) &&
-      !isDisabled(updateRiskParams.updateId)
-    );
+      !isDisabled(updateRiskParams.updateId));
   }
 
   /**

--- a/src/contracts/AaveStewardInjector.sol
+++ b/src/contracts/AaveStewardInjector.sol
@@ -50,7 +50,7 @@ contract AaveStewardInjector is Ownable, IAaveStewardInjector {
     address riskSteward,
     address guardian,
     address whitelistedAsset
-  ) Ownable(riskSteward) {
+  ) Ownable(guardian) {
     RISK_ORACLE = riskOracle;
     RISK_STEWARD = riskSteward;
     WHITELISTED_ASSET = whitelistedAsset;

--- a/src/contracts/AaveStewardInjector.sol
+++ b/src/contracts/AaveStewardInjector.sol
@@ -54,7 +54,6 @@ contract AaveStewardInjector is Ownable, IAaveStewardInjector {
     RISK_ORACLE = riskOracle;
     RISK_STEWARD = riskSteward;
     WHITELISTED_ASSET = whitelistedAsset;
-    _transferOwnership(guardian);
   }
 
   /**

--- a/src/contracts/RiskSteward.sol
+++ b/src/contracts/RiskSteward.sol
@@ -59,7 +59,7 @@ contract RiskSteward is Ownable, IRiskSteward {
     IEngine engine,
     address riskCouncil,
     Config memory riskConfig
-  ) Ownable(riskCouncil) {
+  ) Ownable(msg.sender) {
     POOL_DATA_PROVIDER = poolDataProvider;
     CONFIG_ENGINE = engine;
     RISK_COUNCIL = riskCouncil;

--- a/src/contracts/RiskSteward.sol
+++ b/src/contracts/RiskSteward.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.0;
 
 import {IPoolDataProvider} from 'aave-address-book/AaveV3.sol';
-import {Address} from 'solidity-utils/contracts/oz-common/Address.sol';
-import {SafeCast} from 'solidity-utils/contracts/oz-common/SafeCast.sol';
+import {Address} from 'openzeppelin-contracts/contracts/utils/Address.sol';
+import {SafeCast} from 'openzeppelin-contracts/contracts/utils/math/SafeCast.sol';
 import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
-import {Ownable} from 'solidity-utils/contracts/oz-common/Ownable.sol';
+import {Ownable} from 'openzeppelin-contracts/contracts/access/Ownable.sol';
 import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
 import {IRiskSteward} from '../interfaces/IRiskSteward.sol';
 import {IDefaultInterestRateStrategyV2} from 'aave-v3-origin/src/contracts/interfaces/IDefaultInterestRateStrategyV2.sol';
@@ -59,7 +59,7 @@ contract RiskSteward is Ownable, IRiskSteward {
     IEngine engine,
     address riskCouncil,
     Config memory riskConfig
-  ) {
+  ) Ownable(riskCouncil) {
     POOL_DATA_PROVIDER = poolDataProvider;
     CONFIG_ENGINE = engine;
     RISK_COUNCIL = riskCouncil;

--- a/tests/RiskSteward.t.sol
+++ b/tests/RiskSteward.t.sol
@@ -10,6 +10,7 @@ import {RiskSteward, IRiskSteward, IEngine, EngineFlags} from 'src/contracts/Ris
 import {IAaveV3ConfigEngine as IEngine} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
 import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
 import {ConfigEngineDeployer} from './utils/ConfigEngineDeployer.sol';
+import {Ownable} from 'openzeppelin-contracts/contracts/access/Ownable.sol';
 
 contract RiskSteward_Test is Test {
   address public constant riskCouncil = address(42);
@@ -907,10 +908,10 @@ contract RiskSteward_Test is Test {
     vm.expectRevert(IRiskSteward.InvalidCaller.selector);
     steward.updateRates(rateStrategyUpdate);
 
-    vm.expectRevert('Ownable: caller is not the owner');
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, caller));
     steward.setRiskConfig(riskConfig);
 
-    vm.expectRevert('Ownable: caller is not the owner');
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, caller));
     steward.setAddressRestricted(AaveV3EthereumAssets.GHO_UNDERLYING, true);
 
     vm.stopPrank();

--- a/tests/RiskStewardCapo.t.sol
+++ b/tests/RiskStewardCapo.t.sol
@@ -12,7 +12,7 @@ import {ConfigEngineDeployer} from './utils/ConfigEngineDeployer.sol';
 import {IPriceCapAdapter} from 'aave-capo/interfaces/IPriceCapAdapter.sol';
 import {IPriceCapAdapterStable, IChainlinkAggregator} from 'aave-capo/interfaces/IPriceCapAdapterStable.sol';
 import {PriceCapAdapterStable} from 'aave-capo/contracts/PriceCapAdapterStable.sol';
-import {SafeCast} from 'solidity-utils/contracts/oz-common/SafeCast.sol';
+import {SafeCast} from 'openzeppelin-contracts/contracts/utils/math/SafeCast.sol';
 
 contract RiskSteward_Capo_Test is Test {
   using SafeCast for uint256;


### PR DESCRIPTION
This PR update aave-helpers lib (in order to get the new assets from aave-address-book).

Due to these last commits from `bgd-labs/solidity-utils`:
- https://github.com/bgd-labs/solidity-utils/commit/1422f3e6cc2ea038e37b1578e713b13b1f6f2dc8
- https://github.com/bgd-labs/solidity-utils/commit/c686d3441357413113ce39193542361e21a17473

I needed to use directely openzeppelin-contracts, instead of former oz-common folder contracts.