### PR TITLE
fix: allow absolute change for discount rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following risk params could be changed by the RiskStewards:
 - Optimal point
 
 - Cap parameters for [PriceCapAdapters (CAPO)](https://github.com/bgd-labs/aave-capo/)
+- Discount Rate for Pendle PT CAPO
 
 - EMode Collateral params (LTV, Liquidation Threshold, Liquidation Bonus)
 
@@ -57,6 +58,9 @@ For each risk param, `maxPercentChange` is the maximum percent change allowed (b
 
 - Stable price cap: the `maxPercentChange` is in relative values.
   For example, for a current price cap of an oracle configured at 1_10_000000 and `maxPercentChange` configured at `1_00`, the max price cap that can be configured is 1_11_100000 and the minimum 1_08_900000 via the steward.
+
+- Pendle discount rate CAPO: the `maxPercentChange` is in absolute values.
+  For example, for a current discount rate of an oracle configured at `0.05e18` (5%) and `maxPercentChange` configured at `0.025e18` (2.5%), the max price cap that can be configured is `0.075e18` (7.5%)  and the minimum `0.025e18` (2.5%) via the steward.
 
 After the activation proposal, these params could only be changed by the governance by calling the `setRiskConfig()` method.
 

--- a/scripts/deploy/DeployStewards.s.sol
+++ b/scripts/deploy/DeployStewards.s.sol
@@ -78,7 +78,7 @@ library DeployRiskStewards {
         priceCapConfig: IRiskSteward.PriceCapConfig({
           priceCapLst: IRiskSteward.RiskParamConfig({minDelay: 3 days, maxPercentChange: 5_00}),
           priceCapStable: IRiskSteward.RiskParamConfig({minDelay: 3 days, maxPercentChange: 50}),
-          discountRatePendle: IRiskSteward.RiskParamConfig({minDelay: 2 days, maxPercentChange: 5_00})
+          discountRatePendle: IRiskSteward.RiskParamConfig({minDelay: 2 days, maxPercentChange: 0.025e18})
         })
       });
   }

--- a/src/contracts/RiskSteward.sol
+++ b/src/contracts/RiskSteward.sol
@@ -484,7 +484,7 @@ contract RiskSteward is Ownable, IRiskSteward {
           newValue: discountRateUpdate[i].discountRate,
           lastUpdated: _timelocks[oracle].priceCapLastUpdated,
           riskConfig: _riskConfig.priceCapConfig.discountRatePendle,
-          isChangeRelative: true
+          isChangeRelative: false
         })
       );
     }

--- a/tests/RiskStewardCapo.t.sol
+++ b/tests/RiskStewardCapo.t.sol
@@ -34,10 +34,14 @@ contract RiskSteward_Capo_Test is Test {
       minDelay: 5 days,
       maxPercentChange: 10_00 // 10%
     });
+    IRiskSteward.RiskParamConfig memory pendleRiskParamConfig = IRiskSteward.RiskParamConfig({
+      minDelay: 5 days,
+      maxPercentChange: 0.1e18 // 10%
+    });
     IRiskSteward.Config memory riskConfig;
     riskConfig.priceCapConfig.priceCapLst = defaultRiskParamConfig;
     riskConfig.priceCapConfig.priceCapStable = defaultRiskParamConfig;
-    riskConfig.priceCapConfig.discountRatePendle = defaultRiskParamConfig;
+    riskConfig.priceCapConfig.discountRatePendle = pendleRiskParamConfig;
 
     steward = new RiskSteward(
       address(AaveV3Ethereum.POOL),
@@ -70,7 +74,7 @@ contract RiskSteward_Capo_Test is Test {
       assetToUsdAggregator: 0x42bc86f2f08419280a99d8fbEa4672e7c30a86ec, // sUSDe capo
       pendlePrincipalToken: 0xb7de5dFCb74d25c2f21841fbd6230355C50d9308, // sUSDe PT token
       maxDiscountRatePerYear: 1e18, // 100%
-      discountRatePerYear: 0.1e18, // 10%
+      discountRatePerYear: 0.2e18, // 20%
       aclManager: address(AaveV3Ethereum.ACL_MANAGER),
       description: 'sUSDe PT Adapter'
     }));
@@ -563,7 +567,7 @@ contract RiskSteward_Capo_Test is Test {
 
     priceCapUpdates[0] = IRiskSteward.DiscountRatePendleUpdate({
       oracle: address(pendleAdapter),
-      discountRate: ((currentDiscount * 110) / 100) // +10% relative change
+      discountRate: currentDiscount + 0.1e18 // +10% absolute change
     });
 
     vm.startPrank(riskCouncil);
@@ -582,7 +586,7 @@ contract RiskSteward_Capo_Test is Test {
 
     priceCapUpdates[0] = IRiskSteward.DiscountRatePendleUpdate({
       oracle: address(pendleAdapter),
-      discountRate: ((currentDiscount * 90) / 100) // -10% relative change
+      discountRate: currentDiscount - 0.1e18 // -10% absolute change
     });
 
     steward.updatePendleDiscountRates(priceCapUpdates);
@@ -603,7 +607,7 @@ contract RiskSteward_Capo_Test is Test {
 
     priceCapUpdates[0] = IRiskSteward.DiscountRatePendleUpdate({
       oracle: address(pendleAdapter),
-      discountRate: ((currentDiscount * 110) / 100) // +10% relative change
+      discountRate: currentDiscount + 0.1e18 // +10% absolute change
     });
 
     vm.startPrank(riskCouncil);
@@ -611,7 +615,7 @@ contract RiskSteward_Capo_Test is Test {
 
     priceCapUpdates[0] = IRiskSteward.DiscountRatePendleUpdate({
       oracle: address(pendleAdapter),
-      discountRate: ((currentDiscount * 105) / 100) // +10% relative change
+      discountRate: currentDiscount + 0.1e18 // +10% absolute change
     });
 
     // expect revert as minimum time has not passed for next update
@@ -626,7 +630,7 @@ contract RiskSteward_Capo_Test is Test {
 
     priceCapUpdates[0] = IRiskSteward.DiscountRatePendleUpdate({
       oracle: address(pendleAdapter),
-      discountRate: ((currentDiscount * 111) / 100) // +11% relative increase
+      discountRate: currentDiscount + 0.11e18 // +11% absolute change
     });
     vm.startPrank(riskCouncil);
 
@@ -636,7 +640,7 @@ contract RiskSteward_Capo_Test is Test {
 
     priceCapUpdates[0] = IRiskSteward.DiscountRatePendleUpdate({
       oracle: address(pendleAdapter),
-      discountRate: ((currentDiscount * 89) / 100) // -11% relative decrease
+      discountRate: currentDiscount - 0.11e18 // -11% absolute change
     });
     vm.expectRevert(IRiskSteward.UpdateNotInRange.selector);
     steward.updatePendleDiscountRates(priceCapUpdates);
@@ -682,7 +686,7 @@ contract RiskSteward_Capo_Test is Test {
 
     priceCapUpdates[0] = IRiskSteward.DiscountRatePendleUpdate({
       oracle: address(pendleAdapter),
-      discountRate: ((currentDiscount * 110) / 100) // +10% relative change
+      discountRate: currentDiscount + 0.1e18 // +10% absolute change
     });
     vm.prank(riskCouncil);
     // expect revert as oracle is restricted


### PR DESCRIPTION
This PR changes configuring maxDiscountRate from relative to absolute value for pendle discount rate CAPO.
On the deploy scripts, we also set the `maxDiscountRate` to be `2.5%` which will be in absolute terms.