### PR TITLE
feat: pendle discount rate injector

### DIFF
--- a/scripts/deploy/DeployDiscountRateInjector.s.sol
+++ b/scripts/deploy/DeployDiscountRateInjector.s.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {ICreate3Factory} from 'solidity-utils/contracts/create3/interfaces/ICreate3Factory.sol';
+import {EdgeRiskStewardDiscountRate, IRiskSteward} from '../../src/contracts/EdgeRiskStewardDiscountRate.sol';
+import {AaveStewardInjectorDiscountRate} from '../../src/contracts/AaveStewardInjectorDiscountRate.sol';
+
+library DeployStewardContracts {
+  function _deployRiskStewards(
+    address pool,
+    address configEngine,
+    address riskCouncil,
+    address governance
+  ) internal returns (address) {
+    address riskSteward = address(
+      new EdgeRiskStewardDiscountRate(pool, configEngine, riskCouncil, governance, _getRiskConfig())
+    );
+    return riskSteward;
+  }
+
+  function _deployDiscountRateStewardInjector(
+    address create3Factory,
+    bytes32 salt,
+    address riskSteward,
+    address aaveOracle,
+    address edgeRiskOracle,
+    address owner,
+    address guardian,
+    address[] memory whitelistedMarkets
+  ) internal returns (address) {
+    address stewardInjector = ICreate3Factory(create3Factory).create(
+      salt,
+      abi.encodePacked(
+        type(AaveStewardInjectorDiscountRate).creationCode,
+        abi.encode(aaveOracle, edgeRiskOracle, riskSteward, whitelistedMarkets, owner, guardian)
+      )
+    );
+    return stewardInjector;
+  }
+
+  function _getRiskConfig() internal pure returns (IRiskSteward.Config memory) {
+    IRiskSteward.Config memory config;
+    config.priceCapConfig.discountRatePendle = IRiskSteward.RiskParamConfig({
+      minDelay: 2 days,
+      maxPercentChange: 0.01e18 // 1%
+    });
+
+    return config;
+  }
+}
+
+// make deploy-ledger contract=scripts/deploy/DeployDiscountRateInjector.s.sol:DeployEthereum chain=mainnet
+contract DeployEthereum is EthereumScript {
+  address constant GUARDIAN = 0xff37939808EcF199A2D599ef91D699Fb13dab7F7;
+  address constant EDGE_RISK_ORACLE = 0x7ABB46C690C52E919687D19ebF89C81A6136C1F2;
+
+  function run() external {
+    vm.startBroadcast();
+    bytes32 salt = 'DiscountRateStewardInjector';
+    address predictedStewardsInjector = ICreate3Factory(MiscEthereum.CREATE_3_FACTORY)
+      .predictAddress(msg.sender, salt);
+
+    address riskSteward = DeployStewardContracts._deployRiskStewards(
+      address(AaveV3Ethereum.POOL),
+      AaveV3Ethereum.CONFIG_ENGINE,
+      predictedStewardsInjector,
+      GovernanceV3Ethereum.EXECUTOR_LVL_1
+    );
+
+    address[] memory whitelistedPendleAssets = new address[](3);
+    whitelistedPendleAssets[0] = AaveV3EthereumAssets.PT_sUSDE_31JUL2025_UNDERLYING;
+    whitelistedPendleAssets[1] = AaveV3EthereumAssets.PT_USDe_31JUL2025_UNDERLYING;
+    whitelistedPendleAssets[2] = AaveV3EthereumAssets.PT_eUSDE_14AUG2025_UNDERLYING;
+
+    DeployStewardContracts._deployDiscountRateStewardInjector(
+      MiscEthereum.CREATE_3_FACTORY,
+      salt,
+      riskSteward,
+      address(AaveV3Ethereum.ORACLE),
+      EDGE_RISK_ORACLE,
+      GovernanceV3Ethereum.EXECUTOR_LVL_1,
+      GUARDIAN,
+      whitelistedPendleAssets
+    );
+    vm.stopBroadcast();
+  }
+}

--- a/src/contracts/AaveStewardInjectorDiscountRate.sol
+++ b/src/contracts/AaveStewardInjectorDiscountRate.sol
@@ -16,20 +16,20 @@ contract AaveStewardInjectorDiscountRate is AaveStewardInjectorBase {
   IAaveOracle public immutable AAVE_ORACLE;
 
   /**
+   * @param aaveOracle address of the aave oracle of the instance.
    * @param riskOracle address of the edge risk oracle contract.
    * @param riskSteward address of the risk steward contract.
    * @param markets list of market addresses to allow.
    * @param owner address of the owner of the stewards injector.
    * @param guardian address of the guardian of the stewards injector.
-   * @param aaveOracle address of the aave oracle of the instance.
    */
   constructor(
+    address aaveOracle,
     address riskOracle,
     address riskSteward,
     address[] memory markets,
     address owner,
-    address guardian,
-    address aaveOracle
+    address guardian
   ) AaveStewardInjectorBase(riskOracle, riskSteward, markets, owner, guardian) {
     AAVE_ORACLE = IAaveOracle(aaveOracle);
   }

--- a/src/contracts/AaveStewardInjectorDiscountRate.sol
+++ b/src/contracts/AaveStewardInjectorDiscountRate.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IRiskOracle} from './dependencies/IRiskOracle.sol';
+import {IRiskSteward} from '../interfaces/IRiskSteward.sol';
+import {AaveStewardInjectorBase} from './AaveStewardInjectorBase.sol';
+import {IAaveOracle} from 'aave-v3-origin/src/contracts/interfaces/IAaveOracle.sol';
+
+/**
+ * @title AaveStewardInjectorDiscountRate
+ * @author BGD Labs
+ * @notice Aave chainlink automation-keeper-compatible contract to perform pendle discountRate update injection
+ *         on risk steward using the edge risk oracle.
+ */
+contract AaveStewardInjectorDiscountRate is AaveStewardInjectorBase {
+  IAaveOracle public immutable AAVE_ORACLE;
+
+  /**
+   * @param riskOracle address of the edge risk oracle contract.
+   * @param riskSteward address of the risk steward contract.
+   * @param markets list of market addresses to allow.
+   * @param owner address of the owner of the stewards injector.
+   * @param guardian address of the guardian of the stewards injector.
+   * @param aaveOracle address of the aave oracle of the instance.
+   */
+  constructor(
+    address riskOracle,
+    address riskSteward,
+    address[] memory markets,
+    address owner,
+    address guardian,
+    address aaveOracle
+  ) AaveStewardInjectorBase(riskOracle, riskSteward, markets, owner, guardian) {
+    AAVE_ORACLE = IAaveOracle(aaveOracle);
+  }
+
+  /// @inheritdoc AaveStewardInjectorBase
+  function getUpdateTypes() public pure override returns (string[] memory updateTypes) {
+    updateTypes = new string[](1);
+    updateTypes[0] = 'PendleDiscountRateUpdate_Core';
+  }
+
+  /// @inheritdoc AaveStewardInjectorBase
+  function _injectUpdate(IRiskOracle.RiskParameterUpdate memory riskParams) internal override {
+    // we get discountRate in BPS from RiskOracle, so we multiply by 1e14 to convert in the format of DiscountRateOracle
+    // as 100% discountRate on the DiscountRateOracle is 1e18
+    uint256 discountRate = abi.decode(
+      abi.encodePacked(new bytes(32 - riskParams.newValue.length), riskParams.newValue),
+      (uint256)
+    ) * 1e14;
+
+    IRiskSteward.DiscountRatePendleUpdate[] memory discountRateUpdate = new IRiskSteward.DiscountRatePendleUpdate[](1);
+    discountRateUpdate[0] = IRiskSteward.DiscountRatePendleUpdate({
+      oracle: AAVE_ORACLE.getSourceOfAsset(riskParams.market), // reserve address is encoded in the market address
+      discountRate: discountRate
+    });
+    IRiskSteward(RISK_STEWARD).updatePendleDiscountRates(discountRateUpdate);
+  }
+}

--- a/src/contracts/EdgeRiskStewardDiscountRate.sol
+++ b/src/contracts/EdgeRiskStewardDiscountRate.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import './RiskSteward.sol';
+
+/**
+ * @title EdgeRiskStewardDiscountRate
+ * @author BGD labs
+ * @notice Contract to manage the PendleDiscountRate updates within configured bound on aave v3 pool.
+ *         To be triggered by the Aave Steward Injector Contract in a automated way via the Edge Risk Oracle.
+ */
+contract EdgeRiskStewardDiscountRate is RiskSteward {
+  /**
+   * @param pool the aave pool to be controlled by the steward
+   * @param engine the config engine to be used by the steward
+   * @param riskCouncil the safe address of the council being able to interact with the steward
+   * @param owner the owner of the risk steward being able to set configs and mark items as restricted
+   * @param riskConfig the risk configuration to setup for each individual risk param
+   */
+  constructor(
+    address pool,
+    address engine,
+    address riskCouncil,
+    address owner,
+    Config memory riskConfig
+  ) RiskSteward(pool, engine, riskCouncil, owner, riskConfig) {}
+
+  /// @inheritdoc IRiskSteward
+  function updateRates(
+    IEngine.RateStrategyUpdate[] calldata
+  ) external virtual override onlyRiskCouncil {
+    revert UpdateNotAllowed();
+  }
+
+  /// @inheritdoc IRiskSteward
+  function updateCaps(IEngine.CapsUpdate[] calldata) external virtual override onlyRiskCouncil {
+    revert UpdateNotAllowed();
+  }
+
+  /// @inheritdoc IRiskSteward
+  function updateCollateralSide(
+    IEngine.CollateralUpdate[] calldata
+  ) external virtual override onlyRiskCouncil {
+    revert UpdateNotAllowed();
+  }
+
+  /// @inheritdoc IRiskSteward
+  function updateEModeCategories(
+    IEngine.EModeCategoryUpdate[] calldata
+  ) external virtual override onlyRiskCouncil {
+    revert UpdateNotAllowed();
+  }
+
+  /// @inheritdoc IRiskSteward
+  function updateLstPriceCaps(
+    PriceCapLstUpdate[] calldata
+  ) external virtual override onlyRiskCouncil {
+    revert UpdateNotAllowed();
+  }
+
+  /// @inheritdoc IRiskSteward
+  function updateStablePriceCaps(
+    PriceCapStableUpdate[] calldata
+  ) external virtual override onlyRiskCouncil {
+    revert UpdateNotAllowed();
+  }
+}

--- a/tests/AaveStewardInjectorDiscountRate.t.sol
+++ b/tests/AaveStewardInjectorDiscountRate.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {AaveStewardInjectorDiscountRate} from '../src/contracts/AaveStewardInjectorDiscountRate.sol';
+import {PendlePriceCapAdapter, IPendlePriceCapAdapter} from 'aave-capo/contracts/PendlePriceCapAdapter.sol';
+import {IAaveStewardInjectorBase} from '../src/interfaces/IAaveStewardInjectorBase.sol';
+import {EdgeRiskStewardDiscountRate} from '../src/contracts/EdgeRiskStewardDiscountRate.sol';
+import {EngineFlags} from 'aave-v3-origin/src/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import './AaveStewardsInjectorBase.t.sol';
+
+contract AaveStewardsInjectorDiscountRate_Test is AaveStewardsInjectorBaseTest {
+  string internal _updateType = 'PendleDiscountRateUpdate_Core';
+
+  address internal _pendlePTAssetOne;
+  address internal _pendlePTAssetTwo;
+
+  function setUp() public override {
+    super.setUp();
+
+    IRiskSteward.Config memory config;
+    config.priceCapConfig.discountRatePendle = IRiskSteward.RiskParamConfig({
+      minDelay: 1 days,
+      maxPercentChange: 1_00 * 1e14 // 1% change allowed
+    });
+
+    // setup risk oracle
+    vm.startPrank(_riskOracleOwner);
+    address[] memory initialSenders = new address[](2);
+    initialSenders[0] = _riskOracleOwner;
+
+    string[] memory initialUpdateTypes = new string[](2);
+    initialUpdateTypes[0] = _updateType;
+    initialUpdateTypes[1] = 'wrongUpdateType';
+
+    _riskOracle = new RiskOracle('RiskOracle', initialSenders, initialUpdateTypes);
+    vm.stopPrank();
+
+    // custom pendle setup
+
+    // assume the already listed weth, wbtc assets as PT Tokens, we will mock the custom PT token behavior on them
+    _pendlePTAssetOne = address(weth);
+    _pendlePTAssetTwo = address(wbtc);
+
+    // mocks so that the currently listed assets behave as Pendle PT assets
+    vm.mockCall(
+      _pendlePTAssetOne,
+      abi.encodeWithSignature("expiry()"),
+      abi.encode(block.timestamp + 120 days)
+    );
+    vm.mockCall(
+      _pendlePTAssetTwo,
+      abi.encodeWithSignature("expiry()"),
+      abi.encode(block.timestamp + 120 days)
+    );
+
+    PendlePriceCapAdapter pendleOneAdapter = new PendlePriceCapAdapter(IPendlePriceCapAdapter.PendlePriceCapAdapterParams({
+      assetToUsdAggregator: contracts.aaveOracle.getSourceOfAsset(_pendlePTAssetOne),
+      pendlePrincipalToken: _pendlePTAssetOne,
+      maxDiscountRatePerYear: 1e18, // 100%
+      discountRatePerYear: 0.2e18, // 20%
+      aclManager: report.aclManager,
+      description: 'PT_1 Adapter'
+    }));
+    PendlePriceCapAdapter pendleTwoAdapter = new PendlePriceCapAdapter(IPendlePriceCapAdapter.PendlePriceCapAdapterParams({
+      assetToUsdAggregator: contracts.aaveOracle.getSourceOfAsset(_pendlePTAssetTwo),
+      pendlePrincipalToken: _pendlePTAssetTwo,
+      maxDiscountRatePerYear: 1e18, // 100%
+      discountRatePerYear: 0.2e18, // 20%
+      aclManager: report.aclManager,
+      description: 'PT_2 Adapter'
+    }));
+
+    address[] memory pendlePTOracles = new address[](2);
+    pendlePTOracles[0] = address(pendleOneAdapter);
+    pendlePTOracles[1] = address(pendleTwoAdapter);
+    address[] memory pendlePTAssets = new address[](2);
+    pendlePTAssets[0] = _pendlePTAssetOne;
+    pendlePTAssets[1] = _pendlePTAssetTwo;
+
+    // updates the listed assets oracle to pendle PT so they behave as pendle assets
+    vm.prank(poolAdmin);
+    contracts.aaveOracle.setAssetSources(pendlePTAssets, pendlePTOracles);
+
+    // setup steward injector
+    vm.startPrank(_stewardsInjectorOwner);
+
+    address computedRiskStewardAddress = vm.computeCreateAddress(
+      _stewardsInjectorOwner,
+      vm.getNonce(_stewardsInjectorOwner) + 1
+    );
+
+    _stewardInjector = new AaveStewardInjectorDiscountRate(
+      report.aaveOracle,
+      address(_riskOracle),
+      address(computedRiskStewardAddress),
+      pendlePTAssets,
+      _stewardsInjectorOwner,
+      _stewardsInjectorGuardian
+    );
+
+    // setup risk steward
+    _riskSteward = new EdgeRiskStewardDiscountRate(
+      address(contracts.poolProxy),
+      report.configEngine,
+      address(_stewardInjector),
+      address(this),
+      config
+    );
+    vm.assertEq(computedRiskStewardAddress, address(_riskSteward));
+    vm.stopPrank();
+
+    vm.prank(poolAdmin);
+    contracts.aclManager.addRiskAdmin(address(_riskSteward));
+  }
+
+  function test_multipleDiscountRateInjection() public {
+    _addUpdateToRiskOracle(_pendlePTAssetOne);
+    _addUpdateToRiskOracle(_pendlePTAssetTwo);
+
+    vm.expectEmit(address(_stewardInjector));
+    emit IAaveStewardInjectorBase.ActionSucceeded(1);
+    assertTrue(_checkAndPerformAutomation());
+
+    vm.expectEmit(address(_stewardInjector));
+    emit IAaveStewardInjectorBase.ActionSucceeded(2);
+    assertTrue(_checkAndPerformAutomation());
+  }
+
+  function test_randomized_multipleEModeInjection() public {
+    _addUpdateToRiskOracle(_pendlePTAssetOne);
+    _addUpdateToRiskOracle(_pendlePTAssetTwo);
+
+    uint256 snapshot = vm.snapshotState();
+
+    vm.expectEmit(address(_stewardInjector));
+    emit IAaveStewardInjectorBase.ActionSucceeded(1);
+    assertTrue(_checkAndPerformAutomation());
+
+    vm.expectEmit(address(_stewardInjector));
+    emit IAaveStewardInjectorBase.ActionSucceeded(2);
+    assertTrue(_checkAndPerformAutomation());
+
+    assertTrue(vm.revertToState(snapshot));
+    vm.warp(block.timestamp + 3);
+
+    // previous updateId order of execution: 1, 2
+    // updateId order of execution:          2, 1
+    // we can see with block.timestamp changing the order of execution of action changes as well
+
+    vm.expectEmit(address(_stewardInjector));
+    emit IAaveStewardInjectorBase.ActionSucceeded(2);
+    assertTrue(_checkAndPerformAutomation());
+
+    vm.expectEmit(address(_stewardInjector));
+    emit IAaveStewardInjectorBase.ActionSucceeded(1);
+    assertTrue(_checkAndPerformAutomation());
+  }
+
+  function test_checkUpkeepGasLimit() public {
+    _addMultipleUpdatesToRiskOracleOfDifferentMarkets(40);
+
+    uint256 startGas = gasleft();
+    _stewardInjector.checkUpkeep('');
+    uint256 gasUsed = startGas - gasleft();
+
+    // for 40 markets added, the checkUpkeep gas consumed is less than 5m
+    // which is within the bounds of automation infra
+    assertLt(gasUsed, 5_000_000);
+  }
+
+  function _addUpdateToRiskOracle()
+    internal
+    override
+    returns (string memory updateType, address market)
+  {
+    vm.startPrank(_riskOracleOwner);
+    updateType = _updateType;
+    market = _pendlePTAssetOne;
+
+    _riskOracle.publishRiskParameterUpdate(
+      'referenceId',
+      _encode(21_00), // 21% discountRate in BPS
+      updateType,
+      market,
+      'additionalData'
+    );
+    vm.stopPrank();
+  }
+
+  function _addUpdateToRiskOracle(
+    address market
+  ) internal override returns (string memory, address) {
+    vm.startPrank(_riskOracleOwner);
+    string memory updateType = _updateType;
+
+    _riskOracle.publishRiskParameterUpdate(
+      'referenceId',
+      _encode(21_00), // 21% discountRate in BPS
+      updateType,
+      market,
+      'additionalData'
+    );
+    vm.stopPrank();
+    return (updateType, market);
+  }
+
+  function _addUpdateToRiskOracle(
+    string memory updateType
+  ) internal override returns (string memory, address) {
+    vm.startPrank(_riskOracleOwner);
+    address market = _pendlePTAssetOne;
+
+    _riskOracle.publishRiskParameterUpdate(
+      'referenceId',
+      _encode(21_00), // 21% discountRate in BPS
+      updateType,
+      market,
+      'additionalData'
+    );
+    vm.stopPrank();
+    return (updateType, market);
+  }
+
+  function _addMultipleUpdatesToRiskOracleOfDifferentMarkets(uint160 count) internal {
+    for (uint160 i = 0; i < count; i++) {
+      vm.startPrank(_riskOracleOwner);
+
+      address market = address(i);
+      _riskOracle.publishRiskParameterUpdate(
+        'referenceId',
+        _encode(21_00),
+        _updateType,
+        market,
+        'additionalData'
+      );
+      vm.stopPrank();
+    }
+  }
+
+  function _encode(uint256 input) internal pure returns (bytes memory encodedData) {
+    encodedData = abi.encodePacked(uint256(input));
+  }
+}

--- a/tests/AaveStewardsInjectorBase.t.sol
+++ b/tests/AaveStewardsInjectorBase.t.sol
@@ -161,17 +161,18 @@ abstract contract AaveStewardsInjectorBaseTest is TestnetProcedures {
     vm.expectEmit(address(_stewardInjector));
     emit IAaveStewardInjectorBase.MarketAdded(marketToAdd);
 
+    address[] memory prevMarkets = _stewardInjector.getMarkets();
+
     vm.prank(_stewardsInjectorOwner);
     _stewardInjector.addMarkets(markets);
 
     address[] memory newMarkets = _stewardInjector.getMarkets();
-    assertEq(newMarkets.length, 2);
-    assertEq(marketToAdd, newMarkets[1]);
+    assertEq(newMarkets.length, prevMarkets.length + 1);
+    assertEq(marketToAdd, newMarkets[prevMarkets.length]);
   }
 
   function test_removeMarkets() public {
     address[] memory markets = _stewardInjector.getMarkets();
-    assertEq(markets.length, 1);
 
     vm.prank(address(1));
     vm.expectRevert(

--- a/tests/EdgeRiskStewardDiscountRate.t.sol
+++ b/tests/EdgeRiskStewardDiscountRate.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {EdgeRiskStewardDiscountRate} from '../src/contracts/EdgeRiskStewardDiscountRate.sol';
+import './RiskStewardCapo.t.sol';
+
+contract EdgeRiskStewardDiscountRate_Test is RiskSteward_Capo_Test {
+  using SafeCast for uint256;
+  using SafeCast for int256;
+
+  function setUp() public override {
+    super.setUp();
+
+    steward = new EdgeRiskStewardDiscountRate(
+      address(AaveV3Ethereum.POOL),
+      AaveV3Ethereum.CONFIG_ENGINE,
+      riskCouncil,
+      GovernanceV3Ethereum.EXECUTOR_LVL_1,
+      riskConfig
+    );
+
+    vm.prank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    AaveV3Ethereum.ACL_MANAGER.addRiskAdmin(address(steward));
+  }
+
+  /* ----------------------------- LST Price Cap Tests ----------------------------- */
+
+  function test_updateLstPriceCap() public override {
+    IRiskSteward.PriceCapLstUpdate[] memory priceCapUpdates = new IRiskSteward.PriceCapLstUpdate[](
+      1
+    );
+
+    vm.prank(riskCouncil);
+    vm.expectRevert(IRiskSteward.UpdateNotAllowed.selector);
+    steward.updateLstPriceCaps(priceCapUpdates);
+  }
+
+  function test_updateLstPriceCaps_debounceNotRespected() public override {}
+
+  function test_updateLstPriceCap_invalidRatio() public override {}
+
+  function test_updateLstPriceCap_outOfRange() public override {}
+
+  function test_updateLstPriceCap_isCapped() public override {}
+
+  function test_updateLstPriceCap_toValueZeroNotAllowed() public override {}
+
+  function test_updateLstPriceCap_oracleRestricted() public override {}
+
+  function test_updateLstPriceCap_noSameUpdate() public override {}
+
+  /* ----------------------------- Stable Price Cap Tests ----------------------------- */
+
+  function test_updateStablePriceCap() public override {}
+
+  function test_updateStablePriceCap_debounceNotRespected() public override {}
+
+  function test_updateStablePriceCap_outOfRange() public override {}
+
+  function test_updateStablePriceCap_keepCurrent_revert() public override {}
+
+  function test_updateStablePriceCap_toValueZeroNotAllowed() public override {}
+
+  function test_updateStablePriceCap_oracleRestricted() public override {}
+
+  function test_updateStablePriceCap_sameUpdates() public override {}
+
+  /* ----------------------------- Rates Tests ----------------------------- */
+
+  function test_updateRates() public {
+    IEngine.RateStrategyUpdate[] memory rateUpdates = new IEngine.RateStrategyUpdate[](1);
+
+    vm.startPrank(riskCouncil);
+    vm.expectRevert(IRiskSteward.UpdateNotAllowed.selector);
+    steward.updateRates(rateUpdates);
+  }
+
+  /* ----------------------------- Caps Tests ----------------------------- */
+
+  function test_updateCaps() public {
+    IEngine.CapsUpdate[] memory capUpdates = new IEngine.CapsUpdate[](1);
+
+    vm.startPrank(riskCouncil);
+    vm.expectRevert(IRiskSteward.UpdateNotAllowed.selector);
+    steward.updateCaps(capUpdates);
+  }
+
+  /* ----------------------------- Collateral Tests ----------------------------- */
+
+  function test_updateCollateralSide() public {
+    IEngine.CollateralUpdate[] memory collateralUpdates = new IEngine.CollateralUpdate[](1);
+
+    vm.startPrank(riskCouncil);
+    vm.expectRevert(IRiskSteward.UpdateNotAllowed.selector);
+    steward.updateCollateralSide(collateralUpdates);
+  }
+
+  /* ----------------------------- EMode Category Update Tests ----------------------------- */
+
+  function test_updateEModeCategories() public {
+    IEngine.EModeCategoryUpdate[] memory eModeCategoryUpdates = new IEngine.EModeCategoryUpdate[](1);
+
+    vm.startPrank(riskCouncil);
+    vm.expectRevert(IRiskSteward.UpdateNotAllowed.selector);
+    steward.updateEModeCategories(eModeCategoryUpdates);
+  }
+}

--- a/tests/RiskStewardCapo.t.sol
+++ b/tests/RiskStewardCapo.t.sol
@@ -22,12 +22,14 @@ contract RiskSteward_Capo_Test is Test {
   address public constant riskCouncil = address(42);
   PendlePriceCapAdapter public pendleAdapter;
   RiskSteward public steward;
+  IRiskSteward.Config public riskConfig;
+
   uint104 currentRatio;
   uint48 delay;
 
   event AddressRestricted(address indexed contractAddress, bool indexed isRestricted);
 
-  function setUp() public {
+  function setUp() public virtual {
     vm.createSelectFork(vm.rpcUrl('mainnet'), 22144636);
 
     IRiskSteward.RiskParamConfig memory defaultRiskParamConfig = IRiskSteward.RiskParamConfig({
@@ -38,7 +40,7 @@ contract RiskSteward_Capo_Test is Test {
       minDelay: 5 days,
       maxPercentChange: 0.1e18 // 10%
     });
-    IRiskSteward.Config memory riskConfig;
+
     riskConfig.priceCapConfig.priceCapLst = defaultRiskParamConfig;
     riskConfig.priceCapConfig.priceCapStable = defaultRiskParamConfig;
     riskConfig.priceCapConfig.discountRatePendle = pendleRiskParamConfig;
@@ -82,7 +84,7 @@ contract RiskSteward_Capo_Test is Test {
 
   /* ----------------------------- LST Price Cap Tests ----------------------------- */
 
-  function test_updateLstPriceCap() public {
+  function test_updateLstPriceCap() public virtual {
     uint256 maxYearlyGrowthPercentBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
       .getMaxYearlyGrowthRatePercent();
 
@@ -153,7 +155,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateLstPriceCaps_debounceNotRespected() public {
+  function test_updateLstPriceCaps_debounceNotRespected() public virtual {
     uint256 maxYearlyGrowthPercentBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
       .getMaxYearlyGrowthRatePercent();
 
@@ -188,7 +190,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateLstPriceCap_invalidRatio() public {
+  function test_updateLstPriceCap_invalidRatio() public virtual {
     uint256 maxYearlyGrowthPercentBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
       .getMaxYearlyGrowthRatePercent();
 
@@ -212,7 +214,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateLstPriceCap_outOfRange() public {
+  function test_updateLstPriceCap_outOfRange() public virtual {
     uint256 maxYearlyGrowthPercentBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
       .getMaxYearlyGrowthRatePercent();
 
@@ -236,7 +238,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateLstPriceCap_isCapped() public {
+  function test_updateLstPriceCap_isCapped() public virtual {
     uint256 maxYearlyGrowthPercentBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
       .getMaxYearlyGrowthRatePercent();
 
@@ -260,7 +262,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateLstPriceCap_toValueZeroNotAllowed() public {
+  function test_updateLstPriceCap_toValueZeroNotAllowed() public virtual {
     uint256 maxYearlyGrowthPercentBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
       .getMaxYearlyGrowthRatePercent();
 
@@ -310,7 +312,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateLstPriceCap_oracleRestricted() public {
+  function test_updateLstPriceCap_oracleRestricted() public virtual {
     vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
     steward.setAddressRestricted(AaveV3EthereumAssets.wstETH_ORACLE, true);
     vm.stopPrank();
@@ -335,7 +337,7 @@ contract RiskSteward_Capo_Test is Test {
     steward.updateLstPriceCaps(priceCapUpdates);
   }
 
-  function test_updateLstPriceCap_noSameUpdate() public {
+  function test_updateLstPriceCap_noSameUpdate() public virtual {
     uint256 maxYearlyGrowthPercentBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
       .getMaxYearlyGrowthRatePercent();
     uint256 snapshotTsBefore = IPriceCapAdapter(AaveV3EthereumAssets.wstETH_ORACLE)
@@ -375,7 +377,7 @@ contract RiskSteward_Capo_Test is Test {
 
   /* ----------------------------- Stable Price Cap Tests ----------------------------- */
 
-  function test_updateStablePriceCap() public {
+  function test_updateStablePriceCap() public virtual {
     uint256 priceCapBefore = IPriceCapAdapterStable(AaveV3EthereumAssets.USDT_ORACLE)
       .getPriceCap()
       .toUint256();
@@ -422,7 +424,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateStablePriceCap_debounceNotRespected() public {
+  function test_updateStablePriceCap_debounceNotRespected() public virtual {
     uint256 priceCapBefore = IPriceCapAdapterStable(AaveV3EthereumAssets.USDT_ORACLE)
       .getPriceCap()
       .toUint256();
@@ -450,7 +452,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateStablePriceCap_outOfRange() public {
+  function test_updateStablePriceCap_outOfRange() public virtual {
     uint256 priceCapBefore = IPriceCapAdapterStable(AaveV3EthereumAssets.USDT_ORACLE)
       .getPriceCap()
       .toUint256();
@@ -472,7 +474,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateStablePriceCap_keepCurrent_revert() public {
+  function test_updateStablePriceCap_keepCurrent_revert() public virtual {
     IRiskSteward.PriceCapStableUpdate[]
       memory priceCapUpdates = new IRiskSteward.PriceCapStableUpdate[](1);
 
@@ -490,7 +492,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateStablePriceCap_toValueZeroNotAllowed() public {
+  function test_updateStablePriceCap_toValueZeroNotAllowed() public virtual {
     IRiskSteward.PriceCapStableUpdate[]
       memory priceCapUpdates = new IRiskSteward.PriceCapStableUpdate[](1);
 
@@ -508,7 +510,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateStablePriceCap_oracleRestricted() public {
+  function test_updateStablePriceCap_oracleRestricted() public virtual {
     vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
     steward.setAddressRestricted(AaveV3EthereumAssets.USDT_ORACLE, true);
     vm.stopPrank();
@@ -534,7 +536,7 @@ contract RiskSteward_Capo_Test is Test {
     vm.stopPrank();
   }
 
-  function test_updateStablePriceCap_sameUpdates() public {
+  function test_updateStablePriceCap_sameUpdates() public virtual {
     uint256 priceCapBefore = IPriceCapAdapterStable(AaveV3EthereumAssets.USDT_ORACLE)
       .getPriceCap()
       .toUint256();


### PR DESCRIPTION
## AaveStewardInjectorDiscountRate

This PR adds the `AaveStewardInjectorDiscountRate` contract to fetch pendle pt oracle discountRate updates from the edgeRiskOracle and inject them via the `AaveRiskSteward` into the protocol.

### Changelog:
- Adds the new `AaveStewardInjectorDiscountRate` contract for discountRate update injection
- Adds the `EdgeRiskStewardDiscountRate` contract to only allow discountRate updates on the Steward to be used by the new injector.

### Configurations:
- discountRate change allowed: 1% absolute change
- delay: 2 days

### Misc Considerations:
- On the `AaveStewardInjectorDiscountRate` contract, the owner / governance has access to update the markets for cap updates
- The PT asset listed on the protocol is used as the market address on the injector contract instead of the discountRate oracle. This is so that even if the discountRate oracle changes on the protocol (which is very unlikely but still), the injector has access to update the discountRate.
- The discountRate value from RiskOracle is encoded in BPS format for better readability.