### PR TITLE
feat: gelato wrapper for cap injector and deploy scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ git-diff :
 	@printf '%s\n%s\n%s\n' "\`\`\`diff" "$$(git diff --no-index --diff-algorithm=patience --ignore-space-at-eol ${before} ${after})" "\`\`\`" > diffs/${out}.md
 
 # Deploy
-deploy-ledger :; FOUNDRY_PROFILE=${chain} forge script $(if $(filter zksync,${chain}),--zksync) ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv, --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify -vvvv --slow --broadcast)
-deploy-pk :; FOUNDRY_PROFILE=${chain} forge script $(if $(filter zksync,${chain}),--zksync) ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv, --private-key ${PRIVATE_KEY} --verify -vvvv --slow --broadcast)
+deploy-ledger :; FOUNDRY_PROFILE=${chain} forge script $(if $(filter zksync,${chain}),--zksync) ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv, --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify --verifier etherscan -vvvv --slow --broadcast)
+deploy-pk :; FOUNDRY_PROFILE=${chain} forge script $(if $(filter zksync,${chain}),--zksync) ${contract} --rpc-url ${chain} $(if ${dry},--sender 0x25F2226B597E8F9514B3F68F00f494cF4f286491 -vvvv, --private-key ${PRIVATE_KEY} --verify --verifier etherscan -vvvv --slow --broadcast --verifier etherscan)
 
 
 run-script:; FOUNDRY_PROFILE=${network} forge script $(if $(filter zksync,${network}),--zksync) ${contract} --rpc-url ${network} --sig "run(bool, bool, bool)" ${broadcast} ${generate_diff} ${skip_timelock} -vv

--- a/scripts/deploy/DeployCapInjector.s.sol
+++ b/scripts/deploy/DeployCapInjector.s.sol
@@ -4,14 +4,25 @@ pragma solidity ^0.8.0;
 import 'solidity-utils/contracts/utils/ScriptUtils.sol';
 import {MiscArbitrum} from 'aave-address-book/MiscArbitrum.sol';
 import {AaveV3Arbitrum, AaveV3ArbitrumAssets} from 'aave-address-book/AaveV3Arbitrum.sol';
+import {MiscOptimism} from 'aave-address-book/MiscOptimism.sol';
+import {AaveV3Optimism, AaveV3OptimismAssets} from 'aave-address-book/AaveV3Optimism.sol';
+import {MiscPolygon} from 'aave-address-book/MiscPolygon.sol';
+import {AaveV3Polygon, AaveV3PolygonAssets} from 'aave-address-book/AaveV3Polygon.sol';
+import {MiscGnosis} from 'aave-address-book/MiscGnosis.sol';
+import {AaveV3Gnosis, AaveV3GnosisAssets} from 'aave-address-book/AaveV3Gnosis.sol';
+import {MiscBNB} from 'aave-address-book/MiscBNB.sol';
+import {AaveV3BNB, AaveV3BNBAssets} from 'aave-address-book/AaveV3BNB.sol';
 import {GovernanceV3Arbitrum} from 'aave-address-book/GovernanceV3Arbitrum.sol';
+import {GovernanceV3Optimism} from 'aave-address-book/GovernanceV3Optimism.sol';
+import {GovernanceV3Polygon} from 'aave-address-book/GovernanceV3Polygon.sol';
+import {GovernanceV3Gnosis} from 'aave-address-book/GovernanceV3Gnosis.sol';
+import {GovernanceV3BNB} from 'aave-address-book/GovernanceV3BNB.sol';
 import {ICreate3Factory} from 'solidity-utils/contracts/create3/interfaces/ICreate3Factory.sol';
 import {EdgeRiskStewardCaps, IRiskSteward} from '../../src/contracts/EdgeRiskStewardCaps.sol';
 import {AaveStewardInjectorCaps} from '../../src/contracts/AaveStewardInjectorCaps.sol';
+import {GelatoAaveStewardInjectorCaps} from '../../src/contracts/gelato/GelatoAaveStewardInjectorCaps.sol';
 
 library DeployStewardContracts {
-  address constant EDGE_RISK_ORACLE = 0x861eeAdB55E41f161F31Acb1BFD4c70E3a964Aed;
-
   function _deployRiskStewards(
     address pool,
     address configEngine,
@@ -32,16 +43,22 @@ library DeployStewardContracts {
 
   function _deployCapsStewardInjector(
     bytes32 salt,
+    address create3Factory,
     address riskSteward,
     address owner,
     address guardian,
-    address[] memory whitelistedMarkets
+    address[] memory whitelistedMarkets,
+    address riskOracle,
+    bool isGelatoInjector
   ) internal returns (address) {
-    address stewardInjector = ICreate3Factory(MiscArbitrum.CREATE_3_FACTORY).create(
+    bytes memory injectorCode = isGelatoInjector ?
+      type(GelatoAaveStewardInjectorCaps).creationCode : type(AaveStewardInjectorCaps).creationCode;
+
+    address stewardInjector = ICreate3Factory(create3Factory).create(
       salt,
       abi.encodePacked(
-        type(AaveStewardInjectorCaps).creationCode,
-        abi.encode(EDGE_RISK_ORACLE, riskSteward, whitelistedMarkets, owner, guardian)
+        injectorCode,
+        abi.encode(riskOracle, riskSteward, whitelistedMarkets, owner, guardian)
       )
     );
     return stewardInjector;
@@ -83,10 +100,11 @@ library DeployStewardContracts {
 // make deploy-ledger contract=scripts/deploy/DeployCapInjector.s.sol:DeployArbitrum chain=arbitrum
 contract DeployArbitrum is ArbitrumScript {
   address constant GUARDIAN = 0x87dFb794364f2B117C8dbaE29EA622938b3Ce465;
+  address constant RISK_ORACLE = 0x861eeAdB55E41f161F31Acb1BFD4c70E3a964Aed;
 
   function run() external {
     vm.startBroadcast();
-    bytes32 salt = 'CapsStewardInjector';
+    bytes32 salt = 'CapStewardInjector';
     address predictedStewardsInjector = ICreate3Factory(MiscArbitrum.CREATE_3_FACTORY)
       .predictAddress(msg.sender, salt);
 
@@ -116,10 +134,178 @@ contract DeployArbitrum is ArbitrumScript {
 
     DeployStewardContracts._deployCapsStewardInjector(
       salt,
+      MiscArbitrum.CREATE_3_FACTORY,
       riskSteward,
       GovernanceV3Arbitrum.EXECUTOR_LVL_1,
       GUARDIAN,
-      whitelistedMarkets
+      whitelistedMarkets,
+      RISK_ORACLE,
+      false
+    );
+    vm.stopBroadcast();
+  }
+}
+
+// make deploy-ledger contract=scripts/deploy/DeployCapInjector.s.sol:DeployOptimism chain=optimism
+contract DeployOptimism is OptimismScript {
+  address constant GUARDIAN = 0x9867Ce43D2a574a152fE6b134F64c9578ce3cE03;
+  address constant RISK_ORACLE = 0x9f6aA2aB14bFF53e4b79A81ce1554F1DFdbb6608;
+
+  function run() external {
+    vm.startBroadcast();
+    bytes32 salt = 'CapStewardInjector';
+    address predictedStewardsInjector = ICreate3Factory(MiscOptimism.CREATE_3_FACTORY)
+      .predictAddress(msg.sender, salt);
+
+    address riskSteward = DeployStewardContracts._deployRiskStewards(
+      address(AaveV3Optimism.POOL),
+      AaveV3Optimism.CONFIG_ENGINE,
+      predictedStewardsInjector,
+      GovernanceV3Optimism.EXECUTOR_LVL_1
+    );
+
+    address[] memory whitelistedMarkets = new address[](7);
+    whitelistedMarkets[0] = AaveV3OptimismAssets.WETH_A_TOKEN;
+    whitelistedMarkets[1] = AaveV3OptimismAssets.USDT_A_TOKEN;
+    whitelistedMarkets[2] = AaveV3OptimismAssets.WBTC_A_TOKEN;
+    whitelistedMarkets[3] = AaveV3OptimismAssets.USDCn_A_TOKEN;
+    whitelistedMarkets[4] = AaveV3OptimismAssets.wstETH_A_TOKEN;
+    whitelistedMarkets[5] = AaveV3OptimismAssets.rETH_A_TOKEN;
+    whitelistedMarkets[6] = AaveV3OptimismAssets.OP_A_TOKEN;
+
+    DeployStewardContracts._deployCapsStewardInjector(
+      salt,
+      MiscOptimism.CREATE_3_FACTORY,
+      riskSteward,
+      GovernanceV3Optimism.EXECUTOR_LVL_1,
+      GUARDIAN,
+      whitelistedMarkets,
+      RISK_ORACLE,
+      false
+    );
+    vm.stopBroadcast();
+  }
+}
+
+// make deploy-ledger contract=scripts/deploy/DeployCapInjector.s.sol:DeployPolygon chain=polygon
+contract DeployPolygon is PolygonScript {
+  address constant GUARDIAN = 0x7683177b05a92e8B169D833718BDF9d0ce809aA9;
+  address constant RISK_ORACLE = 0x9f6aA2aB14bFF53e4b79A81ce1554F1DFdbb6608;
+
+  function run() external {
+    vm.startBroadcast();
+    bytes32 salt = 'CapStewardInjector';
+    address predictedStewardsInjector = ICreate3Factory(MiscPolygon.CREATE_3_FACTORY)
+      .predictAddress(msg.sender, salt);
+
+    address riskSteward = DeployStewardContracts._deployRiskStewards(
+      address(AaveV3Polygon.POOL),
+      AaveV3Polygon.CONFIG_ENGINE,
+      predictedStewardsInjector,
+      GovernanceV3Polygon.EXECUTOR_LVL_1
+    );
+
+    address[] memory whitelistedMarkets = new address[](10);
+    whitelistedMarkets[0] = AaveV3PolygonAssets.WETH_A_TOKEN;
+    whitelistedMarkets[1] = AaveV3PolygonAssets.USDC_A_TOKEN;
+    whitelistedMarkets[2] = AaveV3PolygonAssets.USDT_A_TOKEN;
+    whitelistedMarkets[3] = AaveV3PolygonAssets.WBTC_A_TOKEN;
+    whitelistedMarkets[4] = AaveV3PolygonAssets.DAI_A_TOKEN;
+    whitelistedMarkets[5] = AaveV3PolygonAssets.USDCn_A_TOKEN;
+    whitelistedMarkets[6] = AaveV3PolygonAssets.LINK_A_TOKEN;
+    whitelistedMarkets[7] = AaveV3PolygonAssets.wstETH_A_TOKEN;
+    whitelistedMarkets[8] = AaveV3PolygonAssets.WPOL_A_TOKEN;
+    whitelistedMarkets[9] = AaveV3PolygonAssets.AAVE_A_TOKEN;
+
+    DeployStewardContracts._deployCapsStewardInjector(
+      salt,
+      MiscPolygon.CREATE_3_FACTORY,
+      riskSteward,
+      GovernanceV3Polygon.EXECUTOR_LVL_1,
+      GUARDIAN,
+      whitelistedMarkets,
+      RISK_ORACLE,
+      false
+    );
+    vm.stopBroadcast();
+  }
+}
+
+// make deploy-ledger contract=scripts/deploy/DeployCapInjector.s.sol:DeployGnosis chain=gnosis
+contract DeployGnosis is GnosisScript {
+  address constant GUARDIAN = 0x4bBBcfF03E94B2B661c5cA9c3BD34f6504591764;
+  address constant RISK_ORACLE = 0x7BD97DD6C199532d11Cf5f55E13a120dB6dd0F4F;
+
+  function run() external {
+    vm.startBroadcast();
+    bytes32 salt = 'CapStewardInjectorV2';
+    address predictedStewardsInjector = ICreate3Factory(MiscGnosis.CREATE_3_FACTORY)
+      .predictAddress(msg.sender, salt);
+
+    address riskSteward = DeployStewardContracts._deployRiskStewards(
+      address(AaveV3Gnosis.POOL),
+      AaveV3Gnosis.CONFIG_ENGINE,
+      predictedStewardsInjector,
+      GovernanceV3Gnosis.EXECUTOR_LVL_1
+    );
+
+    address[] memory whitelistedMarkets = new address[](6);
+    whitelistedMarkets[0] = AaveV3GnosisAssets.WETH_A_TOKEN;
+    whitelistedMarkets[1] = AaveV3GnosisAssets.USDCe_A_TOKEN;
+    whitelistedMarkets[2] = AaveV3GnosisAssets.sDAI_A_TOKEN;
+    whitelistedMarkets[3] = AaveV3GnosisAssets.EURe_A_TOKEN;
+    whitelistedMarkets[4] = AaveV3GnosisAssets.GNO_A_TOKEN;
+    whitelistedMarkets[5] = AaveV3GnosisAssets.wstETH_A_TOKEN;
+
+    DeployStewardContracts._deployCapsStewardInjector(
+      salt,
+      MiscGnosis.CREATE_3_FACTORY,
+      riskSteward,
+      GovernanceV3Gnosis.EXECUTOR_LVL_1,
+      GUARDIAN,
+      whitelistedMarkets,
+      RISK_ORACLE,
+      true
+    );
+    vm.stopBroadcast();
+  }
+}
+
+// make deploy-ledger contract=scripts/deploy/DeployCapInjector.s.sol:DeployBNB chain=bnb
+contract DeployBNB is BNBScript {
+  address constant GUARDIAN = 0xB5ABc2BcB050bE70EF53338E547d87d06F7c877d;
+  address constant RISK_ORACLE = 0x239d3Bc5fa247337287cb03f53B8bc63DBBc332D;
+
+  function run() external {
+    vm.startBroadcast();
+    bytes32 salt = 'CapStewardInjector';
+    address predictedStewardsInjector = ICreate3Factory(MiscBNB.CREATE_3_FACTORY)
+      .predictAddress(msg.sender, salt);
+
+    address riskSteward = DeployStewardContracts._deployRiskStewards(
+      address(AaveV3BNB.POOL),
+      AaveV3BNB.CONFIG_ENGINE,
+      predictedStewardsInjector,
+      GovernanceV3BNB.EXECUTOR_LVL_1
+    );
+
+    address[] memory whitelistedMarkets = new address[](6);
+    whitelistedMarkets[0] = AaveV3BNBAssets.BTCB_A_TOKEN;
+    whitelistedMarkets[1] = AaveV3BNBAssets.WBNB_A_TOKEN;
+    whitelistedMarkets[2] = AaveV3BNBAssets.USDT_A_TOKEN;
+    whitelistedMarkets[3] = AaveV3BNBAssets.USDC_A_TOKEN;
+    whitelistedMarkets[4] = AaveV3BNBAssets.ETH_A_TOKEN;
+    whitelistedMarkets[5] = AaveV3BNBAssets.wstETH_A_TOKEN;
+
+    DeployStewardContracts._deployCapsStewardInjector(
+      salt,
+      MiscArbitrum.CREATE_3_FACTORY,
+      riskSteward,
+      GovernanceV3BNB.EXECUTOR_LVL_1,
+      GUARDIAN,
+      whitelistedMarkets,
+      RISK_ORACLE,
+      false
     );
     vm.stopBroadcast();
   }

--- a/src/contracts/gelato/GelatoAaveStewardInjectorCaps.sol
+++ b/src/contracts/gelato/GelatoAaveStewardInjectorCaps.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {AaveStewardInjectorCaps, AaveStewardInjectorBase} from '../AaveStewardInjectorCaps.sol';
+
+/**
+ * @title GelatoAaveStewardInjectorCaps
+ * @author BGD Labs
+ * @notice Contract to perform caps update automation using Gelato.
+ */
+contract GelatoAaveStewardInjectorCaps is AaveStewardInjectorCaps {
+  /**
+   * @param riskOracle address of the edge risk oracle contract.
+   * @param riskSteward address of the risk steward contract.
+   * @param markets list of market addresses to allow.
+   * @param owner address of the owner of the stewards injector.
+   * @param guardian address of the guardian of the stewards injector.
+   */
+  constructor(
+    address riskOracle,
+    address riskSteward,
+    address[] memory markets,
+    address owner,
+    address guardian
+  ) AaveStewardInjectorCaps(riskOracle, riskSteward, markets, owner, guardian) {}
+
+  /**
+   * @inheritdoc AaveStewardInjectorBase
+   * @dev the returned bytes is specific to gelato and is encoded with the function selector.
+   */
+  function checkUpkeep(bytes memory) public view override returns (bool, bytes memory) {
+    (bool upkeepNeeded, bytes memory encodedActionDataToExecute) = super.checkUpkeep('');
+    return (upkeepNeeded, abi.encodeCall(this.performUpkeep, encodedActionDataToExecute));
+  }
+}

--- a/tests/AaveStewardInjectorDiscountRate.t.sol
+++ b/tests/AaveStewardInjectorDiscountRate.t.sol
@@ -106,7 +106,6 @@ contract AaveStewardsInjectorDiscountRate_Test is AaveStewardsInjectorBaseTest {
       address(this),
       config
     );
-    vm.assertEq(computedRiskStewardAddress, address(_riskSteward));
     vm.stopPrank();
 
     vm.prank(poolAdmin);

--- a/tests/AaveStewardInjectorEMode.t.sol
+++ b/tests/AaveStewardInjectorEMode.t.sol
@@ -67,7 +67,6 @@ contract AaveStewardsInjectorEMode_Test is AaveStewardsInjectorBaseTest {
       address(this),
       riskConfig
     );
-    vm.assertEq(computedRiskStewardAddress, address(_riskSteward));
     vm.stopPrank();
 
     vm.startPrank(poolAdmin);

--- a/tests/AaveStewardsInjectorBase.t.sol
+++ b/tests/AaveStewardsInjectorBase.t.sol
@@ -139,12 +139,12 @@ abstract contract AaveStewardsInjectorBaseTest is TestnetProcedures {
     vm.expectEmit(address(_stewardInjector));
     emit IAaveStewardInjectorBase.ActionSucceeded(1);
 
-    (bool shouldRunKeeper, bytes memory performData) = _stewardInjector.checkUpkeep('');
-    _stewardInjector.performUpkeep(performData);
-    assertTrue(shouldRunKeeper);
+    (, bytes memory performData) = _stewardInjector.checkUpkeep('');
+    bool isAutomationPerformed = _checkAndPerformAutomation();
+    assertTrue(isAutomationPerformed);
 
     vm.expectRevert(IAaveStewardInjectorBase.UpdateCannotBeInjected.selector);
-    _stewardInjector.performUpkeep(performData);
+    _performAutomation(performData);
   }
 
   function test_addMarkets() public {
@@ -236,5 +236,9 @@ abstract contract AaveStewardsInjectorBaseTest is TestnetProcedures {
       _stewardInjector.performUpkeep(performData);
     }
     return shouldRunKeeper;
+  }
+
+  function _performAutomation(bytes memory performData) internal virtual {
+    _stewardInjector.performUpkeep(performData);
   }
 }

--- a/tests/AaveStewardsInjectorCaps.t.sol
+++ b/tests/AaveStewardsInjectorCaps.t.sol
@@ -13,7 +13,7 @@ contract AaveStewardsInjectorCaps_Test is AaveStewardsInjectorBaseTest {
   address internal _aWETH;
   address internal _aWBTC;
 
-  function setUp() public override {
+  function setUp() public virtual override {
     super.setUp();
 
     IRiskSteward.RiskParamConfig memory defaultRiskParamConfig = IRiskSteward.RiskParamConfig({

--- a/tests/AaveStewardsInjectorCaps.t.sol
+++ b/tests/AaveStewardsInjectorCaps.t.sol
@@ -65,7 +65,6 @@ contract AaveStewardsInjectorCaps_Test is AaveStewardsInjectorBaseTest {
       address(this),
       riskConfig
     );
-    vm.assertEq(computedRiskStewardAddress, address(_riskSteward));
     vm.stopPrank();
 
     vm.startPrank(poolAdmin);

--- a/tests/AaveStewardsInjectorRates.t.sol
+++ b/tests/AaveStewardsInjectorRates.t.sol
@@ -56,8 +56,6 @@ contract AaveStewardsInjectorRates_Test is AaveStewardsInjectorBaseTest {
       address(this),
       riskConfig
     );
-
-    vm.assertEq(computedRiskStewardAddress, address(_riskSteward));
     vm.stopPrank();
 
     vm.startPrank(poolAdmin);

--- a/tests/GelatoAaveStewardInjectorCaps.t.sol
+++ b/tests/GelatoAaveStewardInjectorCaps.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Address} from 'openzeppelin-contracts/contracts/utils/Address.sol';
+import {GelatoAaveStewardInjectorCaps} from '../src/contracts/gelato/GelatoAaveStewardInjectorCaps.sol';
+import './AaveStewardsInjectorCaps.t.sol';
+
+contract GelatoAaveStewardsInjectorCaps_Test is AaveStewardsInjectorCaps_Test {
+  using Address for address;
+
+  function setUp() public override {
+    super.setUp();
+
+    IRiskSteward.RiskParamConfig memory defaultRiskParamConfig = IRiskSteward.RiskParamConfig({
+      minDelay: 3 days,
+      maxPercentChange: 100_00
+    });
+    IRiskSteward.Config memory riskConfig;
+    riskConfig.capConfig.supplyCap = defaultRiskParamConfig;
+    riskConfig.capConfig.borrowCap = defaultRiskParamConfig;
+
+    // setup steward injector
+    vm.startPrank(_stewardsInjectorOwner);
+
+    address computedRiskStewardAddress = vm.computeCreateAddress(
+      _stewardsInjectorOwner,
+      vm.getNonce(_stewardsInjectorOwner) + 1
+    );
+    address[] memory markets = new address[](1);
+    markets[0] = _aWETH;
+
+    _stewardInjector = new GelatoAaveStewardInjectorCaps(
+      address(_riskOracle),
+      address(computedRiskStewardAddress),
+      markets,
+      _stewardsInjectorOwner,
+      _stewardsInjectorGuardian
+    );
+
+    // setup risk steward
+    _riskSteward = new EdgeRiskStewardCaps(
+      address(contracts.poolProxy),
+      report.configEngine,
+      address(_stewardInjector),
+      address(this),
+      riskConfig
+    );
+    vm.assertEq(computedRiskStewardAddress, address(_riskSteward));
+    vm.stopPrank();
+
+    vm.prank(poolAdmin);
+    contracts.aclManager.addRiskAdmin(address(_riskSteward));
+  }
+
+  function _checkAndPerformAutomation() internal virtual override returns (bool) {
+    (bool shouldRunKeeper, bytes memory encodedPerformData) = _stewardInjector.checkUpkeep('');
+    if (shouldRunKeeper) {
+      (bool status, ) = address(_stewardInjector).call(encodedPerformData);
+      assertTrue(status, 'Perform Upkeep Failed');
+    }
+    return shouldRunKeeper;
+  }
+
+  function _performAutomation(bytes memory encodedCalldata) internal override {
+    address(_stewardInjector).functionCall(encodedCalldata);
+  }
+}

--- a/tests/GelatoAaveStewardInjectorCaps.t.sol
+++ b/tests/GelatoAaveStewardInjectorCaps.t.sol
@@ -55,8 +55,7 @@ contract GelatoAaveStewardsInjectorCaps_Test is AaveStewardsInjectorCaps_Test {
   function _checkAndPerformAutomation() internal virtual override returns (bool) {
     (bool shouldRunKeeper, bytes memory encodedPerformData) = _stewardInjector.checkUpkeep('');
     if (shouldRunKeeper) {
-      (bool status, ) = address(_stewardInjector).call(encodedPerformData);
-      assertTrue(status, 'Perform Upkeep Failed');
+      address(_stewardInjector).functionCall(encodedPerformData);
     }
     return shouldRunKeeper;
   }

--- a/tests/GelatoAaveStewardInjectorCaps.t.sol
+++ b/tests/GelatoAaveStewardInjectorCaps.t.sol
@@ -45,7 +45,6 @@ contract GelatoAaveStewardsInjectorCaps_Test is AaveStewardsInjectorCaps_Test {
       address(this),
       riskConfig
     );
-    vm.assertEq(computedRiskStewardAddress, address(_riskSteward));
     vm.stopPrank();
 
     vm.prank(poolAdmin);


### PR DESCRIPTION
- Adds a gelato wrapper for `AaveStewardInjectorCaps` contract so we can use it on gnosis gelato automation infra.
- Adds deploy scripts for CapsInjector for Optimism, Polygon, Gnosis, BNB networks along with whitelisting the assets at the time of deployment

The gelato wrapper is similar to what we already have for other robots [here](https://github.com/bgd-labs/aave-governance-v3-robot/blob/main/src/contracts/gelato/GelatoGasCappedExecutionChainRobotKeeper.sol#L22-L29).

For the assets to whitelist on the injector, we whitelist all the non-frozen assets listed on the protocol except the following as approved by Chaos and as per [this](https://governance.aave.com/t/arfc-addendum-supply-and-borrow-cap-risk-oracle-constraint-specification/22074):
- Optimism: LUSD, sUSD, DAI, AAVE, LINK, USDC.e
- Polygon: MaticX, EURS, GHST
- Gnosis: USDC, xDAI
- BNB: FDUSD, Cake